### PR TITLE
Fix book update functionality on lcp server

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -86,7 +86,7 @@ func (i dbIndex) Update(c Content) error {
 		return err
 	}
 	defer add.Close()
-	_, err = add.Exec(c.EncryptionKey, c.Location, c.Length, c.Sha256, c.Id, c.Type)
+	_, err = add.Exec(c.EncryptionKey, c.Location, c.Length, c.Sha256, c.Type, c.Id)
 	return err
 }
 


### PR DESCRIPTION
Whenever an existing book on lcpserver was updated, the db was not updated. This commit fixes the sql statement, making it possible to update properly.